### PR TITLE
Copy SESP (ApprovedRevs) properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - env: DB=mysql; MW=REL1_31; TYPE=coverage; PHPUNIT=4.8.*
+    - env: DB=mysql; MW=REL1_31; TYPE=coverage; PHPUNIT=5.7.*; APPROVED_REVS=1.0
       php: 7.1
-    - env: DB=mysql; MW=master; PHPUNIT=4.8.*
+    - env: DB=mysql; MW=master; PHPUNIT=6.5.*; APPROVED_REVS=1.0
       php: 7.2
-    - env: DB=sqlite; MW=REL1_31; SITELANG=ja; PHPUNIT=4.8.*
-      php: 5.6
+    - env: DB=sqlite; MW=REL1_31; SITELANG=ja; PHPUNIT=6.5.*; APPROVED_REVS=1.0
+      php: 7.1
 
 install:
   - composer self-update

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 [![Latest Stable Version](https://poser.pugx.org/mediawiki/semantic-approved-revs/version.png)](https://packagist.org/packages/mediawiki/semantic-approved-revs)
 [![Packagist download count](https://poser.pugx.org/mediawiki/semantic-approved-revs/d/total.png)](https://packagist.org/packages/mediawiki/semantic-approved-revs)
 
-Semantic Approved Revs (a.k.a. SAR) is an extension to [Semantic MediaWiki][smw] and complements the Approved Revs extension to control the storage of approved revision content.
+Semantic Approved Revs (a.k.a. SAR) is an extension to [Semantic MediaWiki][smw] and complements the Approved Revs extension to control the storage of approved revision content. The extension provides:
+
+- Control of Semantic MediaWiki relates updates to match those of the `Approved Revs` hereby ensuring that only data of the approved revision is used for the storage
+- Provides additional properties (`Approved by`, `Approved date`, `Approved revision`, and `Approval status`) to accompany the approval process
 
 ## Requirements
 
@@ -18,7 +21,7 @@ Semantic Approved Revs (a.k.a. SAR) is an extension to [Semantic MediaWiki][smw]
 
 The recommended way to install Semantic Approved Revs is by using [Composer][composer].
 
-1. Either execute `composer require mediawiki/semantic-approved-revs:~2.0` from your MediaWiki installation directory or add an entry to MediaWiki's "composer.local.json" file with:
+1. Either execute `composer require mediawiki/semantic-approved-revs:~1.0` from your MediaWiki installation directory or add an entry to MediaWiki's "composer.local.json" file with:
 ```json
 {
 	"require": {

--- a/SemanticApprovedRevs.php
+++ b/SemanticApprovedRevs.php
@@ -71,7 +71,7 @@ class SemanticApprovedRevs {
 			}
 		}
 
-		if ( defined( 'SESP_VERSION' ) && version_compare( SESP_VERSION, '2.1.0', '<' ) && ( $prop = Hooks::hasPropertyDefCollisions( $GLOBALS ) ) !== false ) {
+		if ( defined( 'SESP_VERSION' ) && version_compare( SESP_VERSION, '2.1.0', '<' ) && ( $prop = Hooks::hasPropertyCollisions( $GLOBALS ) ) !== false ) {
 			die(
 				"\nPlease remove the `$prop` property (defined by the SemanticExtraSpecialProperties extension) and switch to the new SESP version 2.1" .
 				" to avoid collision with the 'Semantic Approved Revs' list of properties.\n"

--- a/extension.json
+++ b/extension.json
@@ -26,7 +26,15 @@
 		"SemanticApprovedRevs": "SemanticApprovedRevs.php",
 		"SMW\\ApprovedRevs\\Hooks": "src/Hooks.php",
 		"SMW\\ApprovedRevs\\ApprovedRevsHandler": "src/ApprovedRevsHandler.php",
-		"SMW\\ApprovedRevs\\ApprovedRevsFacade": "src/ApprovedRevsFacade.php"
+		"SMW\\ApprovedRevs\\ApprovedRevsFacade": "src/ApprovedRevsFacade.php",
+		"SMW\\ApprovedRevs\\PropertyRegistry": "src/PropertyRegistry.php",
+		"SMW\\ApprovedRevs\\PropertyAnnotator": "src/PropertyAnnotator.php",
+		"SMW\\ApprovedRevs\\ServicesFactory": "src/ServicesFactory.php",
+		"SMW\\ApprovedRevs\\DatabaseLogReader": "src/DatabaseLogReader.php",
+		"SMW\\ApprovedRevs\\PropertyAnnotators\\ApprovedStatusPropertyAnnotator": "src/PropertyAnnotators/ApprovedStatusPropertyAnnotator.php",
+		"SMW\\ApprovedRevs\\PropertyAnnotators\\ApprovedByPropertyAnnotator": "src/PropertyAnnotators/ApprovedByPropertyAnnotator.php",
+		"SMW\\ApprovedRevs\\PropertyAnnotators\\ApprovedDatePropertyAnnotator": "src/PropertyAnnotators/ApprovedDatePropertyAnnotator.php",
+		"SMW\\ApprovedRevs\\PropertyAnnotators\\ApprovedRevPropertyAnnotator": "src/PropertyAnnotators/ApprovedRevPropertyAnnotator.php"
 },
 	"load_composer_autoloader":true,
 	"manifest_version": 1

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6,5 +6,13 @@
 		]
 	},
 	"semantic-approvedrevs-desc": "Complementary extension to Semantic MediaWiki and Approved Revs to control the storage of approved revision content.",
-	"semantic-approvedrevs-name": "Semantic Approved Revs"
+	"semantic-approvedrevs-name": "Semantic Approved Revs",
+	"semantic-approvedrevs-property-approved-rev": "Approved revision",
+	"semantic-approvedrevs-property-approved-rev-desc": "\"$1\" identifies the revision ID of a page that has been approved and is provided by the [https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Approved_Revs Semantic Approved Revs] extension.",
+	"semantic-approvedrevs-property-approved-by": "Approved by",
+	"semantic-approvedrevs-property-approved-by-desc": "\"$1\" identifies the user who set the approval status of the page and is provided by the [https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Approved_Revs Semantic Approved Revs] extension.",
+	"semantic-approvedrevs-property-approved-date": "Approved date",
+	"semantic-approvedrevs-property-approved-date-desc": "\"$1\" identifies the time when the approval status of the page was set and is provided by the [https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Approved_Revs Semantic Approved Revs] extension.",
+	"semantic-approvedrevs-property-approved-status": "Approval status",
+	"semantic-approvedrevs-property-approved-status-desc": "\"$1\" identifies the approval status of a page and is provided by the [https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Approved_Revs Semantic Approved Revs] extension."
 }

--- a/src/DatabaseLogReader.php
+++ b/src/DatabaseLogReader.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace SMW\ApprovedRevs;
+
+use ArrayIterator;
+use DatabaseLogEntry;
+use DatabaseBase;
+use MWTimestamp;
+use Title;
+use User;
+
+class DatabaseLogReader {
+
+	/**
+	 * @var array
+	 */
+	private static $titleCache = [];
+
+	/**
+	 * @var DatabaseBase
+	 */
+	private $dbr;
+
+	/**
+	 * @var string
+	 */
+	private $query;
+
+	/**
+	 * @var string
+	 */
+	private $log;
+
+	/**
+	 * @var string
+	 */
+	private $dbKey;
+
+	/**
+	 * @var string
+	 */
+	private $type;
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param DatabaseaBase $dbr injected connection
+	 * @param Title|null $title
+	 * @param string $type of log (default: approval)
+	 */
+	public function __construct( DatabaseBase $dbr, Title $title = null , $type = 'approval' ) {
+		$this->dbr = $dbr;
+		$this->dbKey = $title instanceof Title ? $title->getDBkey() : null;
+		$this->type = $type;
+	}
+
+	/**
+	 * @since 1.0
+	 */
+	public function clearCache() {
+		self::$titleCache = [];
+	}
+
+	/**
+	 * Fetch the query parameters for later calls
+	 *
+	 * @since 1.0
+	 *
+	 * @return array of parameters for SELECT call
+	 */
+	public function getQuery() {
+		return $this->query;
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param Title|null $title
+	 * @param string $type
+	 *
+	 * @return User
+	 */
+	public function getUserForLogEntry( Title $title = null, $type = 'approval' ) {
+
+		$this->init( $title, $type );
+		$logLine = $this->getLog()->current();
+
+		if ( $logLine && $logLine->user_id ) {
+			return User::newFromID( $logLine->user_id );
+		}
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param Title|null $title
+	 * @param string $type
+	 *
+	 * @return Timestamp
+	 */
+	public function getDateOfLogEntry( Title $title = null, $type = 'approval' ) {
+
+		$this->init( $title, $type );
+		$logLine = $this->getLog()->current();
+
+		if ( $logLine && $logLine->log_timestamp ) {
+			return new MWTimestamp( $logLine->log_timestamp );
+		}
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param Title|null $title
+	 * @param string $type
+	 *
+	 * @return string
+	 */
+	public function getStatusOfLogEntry( Title $title = null, $type = 'approval' ) {
+
+		$this->init( $title, $type );
+		$logLine = $this->getLog()->current();
+
+		if ( $logLine && $logLine->log_action ) {
+			return $logLine->log_action;
+		}
+	}
+
+	/**
+	 * Take care of loading from the cache or filling the query.
+	 */
+	private function init( $title, $type ) {
+
+		$this->dbKey = $title instanceof Title ? $title->getDBkey() : null;
+		$this->type = $type;
+
+		if ( $this->query ) {
+			return;
+		}
+
+		if ( !isset( self::$titleCache[ $this->dbKey . '#' . $this->type ] ) ) {
+			$this->query = DatabaseLogEntry::getSelectQueryData();
+
+			$this->query['conds'] = [
+				'log_type' => $this->type,
+				'log_title' => $this->dbKey
+			];
+			$this->query['options'] = [ 'ORDER BY' => 'log_timestamp desc' ];
+			self::$titleCache[ $this->dbKey ] = $this;
+		} else {
+			$cache = self::$titleCache[ $this->dbKey . '#' . $this->type ];
+			$this->query = $cache->getQuery();
+			$this->log = $cache->getLog();
+		}
+
+	}
+
+	/**
+	 * Fetch the results using our conditions
+	 *
+	 * @return IResultWrapper
+	 * @throws DBError
+	 */
+	private function getLog() {
+
+		if ( $this->log !== null ) {
+			return $this->log;
+		}
+
+		$query = $this->getQuery();
+
+		$this->log = $this->dbr->select(
+			$query['tables'],
+			$query['fields'],
+			$query['conds'],
+			__METHOD__,
+			$query['options'],
+			$query['join_conds']
+		);
+
+		if ( $this->log === null ) {
+			$this->log = new ArrayIterator(
+				[ (object)[
+					'user_id' => null,
+					'log_timestamp' => null,
+					'log_action' => null
+				] ]
+			);
+		}
+
+		return $this->log;
+	}
+
+}

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -2,6 +2,8 @@
 
 namespace SMW\ApprovedRevs;
 
+use SMW\ApplicationFactory;
+
 /**
  * @license GNU GPL v2+
  * @since 1.0
@@ -22,6 +24,32 @@ class Hooks {
 	 */
 	public function __construct( $config = [] ) {
 		$this->registerHandlers( $config );
+	}
+
+	/**
+	 * @since  1.0
+	 */
+	public static function hasPropertyCollisions( $var ) {
+
+		if ( !isset( $var['sespgEnabledPropertyList'] ) ) {
+			return false;
+		}
+
+		// SESP properties!
+		$list = [
+			'_APPROVED' => true,
+			'_APPROVEDBY' => true,
+			'_APPROVEDDATE' => true,
+			'_APPROVEDSTATUS' => true
+		];
+
+		foreach ( $var['sespgEnabledPropertyList'] as $key ) {
+			if ( isset( $list[$key] ) ) {
+				return $key;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -77,7 +105,7 @@ class Hooks {
 	 * @param Title $title
 	 * @param integer $latestRevID
 	 */
-	public function onApprovedUpdate( $title, $latestRevID ) {
+	public function onSkipUpdate( $title, $latestRevID ) {
 
 		$approvedRevsHandler =  new ApprovedRevsHandler(
 			new ApprovedRevsFacade()
@@ -120,12 +148,53 @@ class Hooks {
 		return true;
 	}
 
-	private function registerHandlers( $config ) {
+	/**
+	 * @see https://www.semantic-mediawiki.org/wiki/Hooks#SMW::Property::initProperties
+	 *
+	 * @since 1.0
+	 *
+	 * @param ProertyRegistry $$registry
+	 * @param integer &$latestRevID
+	 */
+	public function onInitProperties( $registry ) {
 
+		$propertyRegistry = new PropertyRegistry();
+		$propertyRegistry->register( $registry );
+
+		return true;
+	}
+
+	/**
+	 * @see https://www.semantic-mediawiki.org/wiki/Hooks#SMWStore::updateDataBefore
+	 *
+	 * @since 1.0
+	 *
+	 * @param ProertyRegistry $$registry
+	 * @param integer &$latestRevID
+	 */
+	public function onUpdateDataBefore( $store, $semanticData ) {
+
+		$propertyAnnotator = new PropertyAnnotator(
+			new ServicesFactory()
+		);
+
+		$propertyAnnotator->setLogger(
+			ApplicationFactory::getInstance()->getMediaWikiLogger( 'smw-approved-revs' )
+		);
+
+		$propertyAnnotator->addAnnotation( $semanticData );
+
+		return true;
+	}
+
+	private function registerHandlers( $config ) {
 		$this->handlers = [
-			'SMW::LinksUpdate::ApprovedUpdate' => [ $this, 'onApprovedUpdate' ],
+			'SMW::LinksUpdate::ApprovedUpdate' => [ $this, 'onSkipUpdate' ],
+			'SMW::DataUpdater::SkipUpdate' => [ $this, 'onSkipUpdate' ],
 			'SMW::Parser::ChangeRevision' => [ $this, 'onChangeRevision' ],
-			'SMW::Factbox::OverrideRevisionID' => [ $this, 'onOverrideRevisionID' ]
+			'SMW::Factbox::OverrideRevisionID' => [ $this, 'onOverrideRevisionID' ],
+			'SMW::Property::initProperties' => [ $this, 'onInitProperties' ],
+			'SMWStore::updateDataBefore' => [ $this, 'onUpdateDataBefore' ]
 		];
 	}
 

--- a/src/PropertyAnnotator.php
+++ b/src/PropertyAnnotator.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace SMW\ApprovedRevs;
+
+use Psr\Log\LoggerAwareTrait;
+use SMW\DIProperty;
+use SMW\SemanticData;
+use SMW\ApprovedRevs\PropertyAnnotators\ApprovedStatusPropertyAnnotator;
+use SMW\ApprovedRevs\PropertyAnnotators\ApprovedByPropertyAnnotator;
+use SMW\ApprovedRevs\PropertyAnnotators\ApprovedDatePropertyAnnotator;
+use SMW\ApprovedRevs\PropertyAnnotators\ApprovedRevPropertyAnnotator;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ *
+ * @author mwjames
+ */
+class PropertyAnnotator {
+
+	use LoggerAwareTrait;
+
+	/**
+	 * @var ServicesFactory
+	 */
+	private $servicesFactory;
+
+	/**
+	 * @var PropertyAnnotator[]
+	 */
+	private $propertyAnnotators = [];
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param ServicesFactory $servicesFactory
+	 */
+	public function __construct( ServicesFactory $servicesFactory ) {
+		$this->servicesFactory = $servicesFactory;
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param SemanticData $semanticData
+	 */
+	public function addAnnotation( SemanticData $semanticData ) {
+
+		$time = microtime( true );
+
+		if ( !$this->canAnnotate( $semanticData->getSubject() ) ) {
+			return;
+		}
+
+		if ( $this->propertyAnnotators === [] ) {
+			$this->initPropertyAnnotators();
+		}
+
+		foreach ( $this->propertyAnnotators as $propertyAnnotator ) {
+			$propertyAnnotator->addAnnotation( $semanticData );
+		}
+
+		$this->logger->info(
+			[ 'SemanticApprovedRevs', 'procTime:{procTime}' ],
+			[ 'procTime' => round( ( microtime( true ) - $time ), 5 ) ]
+		);
+	}
+
+	private function canAnnotate( $subject ) {
+
+		if ( $subject === null || $subject->getTitle() === null || $subject->getTitle()->isSpecialPage() ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private function initPropertyAnnotators() {
+		$this->propertyAnnotators[] = $this->servicesFactory->newApprovedByPropertyAnnotator();
+		$this->propertyAnnotators[] = $this->servicesFactory->newApprovedStatusPropertyAnnotator();
+		$this->propertyAnnotators[] = $this->servicesFactory->newApprovedDatePropertyAnnotator();
+		$this->propertyAnnotators[] = $this->servicesFactory->newApprovedRevPropertyAnnotator();
+	}
+
+}

--- a/src/PropertyAnnotators/ApprovedByPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ApprovedByPropertyAnnotator.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace SMW\ApprovedRevs\PropertyAnnotators;
+
+use SMW\DIProperty;
+use SMW\SemanticData;
+use SMW\DIWikiPage;
+use SMW\ApprovedRevs\DatabaseLogReader;
+use SMW\ApprovedRevs\PropertyRegistry;
+use User;
+use Title;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ */
+class ApprovedByPropertyAnnotator {
+
+	/**
+	 * @var DatabaseLogReader
+	 */
+	private $databaseLogReader;
+
+	/**
+	 * @var Integer|null
+	 */
+	private $approvedBy;
+
+	/**
+	 * @param DatabaseLogReader $databaseLogReader
+	 */
+	public function __construct( DatabaseLogReader $databaseLogReader ) {
+		$this->databaseLogReader = $databaseLogReader;
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param string $approvedBy
+	 */
+	public function setApprovedBy( $approvedBy ) {
+		$this->approvedBy = $approvedBy;
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @return DIProperty
+	 */
+	public function newDIProperty() {
+		return new DIProperty( PropertyRegistry::SAR_PROP_APPROVED_BY );
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param SemanticData $semanticData
+	 */
+	public function addAnnotation( SemanticData $semanticData ) {
+
+		if ( $this->approvedBy === null ) {
+			$this->approvedBy = $this->databaseLogReader->getUserForLogEntry(
+				$semanticData->getSubject()->getTitle(),
+				'approval'
+			);
+		}
+
+		$property = $this->newDIProperty();
+		$dataItem = $this->newDIWikiPage();
+		$semanticData->removeProperty( $property );
+
+		if ( $dataItem ) {
+			$semanticData->addPropertyObjectValue( $property, $dataItem );
+		}
+	}
+
+	private function newDIWikiPage() {
+
+		if ( !$this->approvedBy instanceof User ) {
+			return;
+		}
+
+		$userPage = $this->approvedBy->getUserPage();
+
+		if ( $userPage instanceof Title ) {
+			return DIWikiPage::newFromTitle( $userPage );
+		}
+	}
+
+}

--- a/src/PropertyAnnotators/ApprovedDatePropertyAnnotator.php
+++ b/src/PropertyAnnotators/ApprovedDatePropertyAnnotator.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace SMW\ApprovedRevs\PropertyAnnotators;
+
+use SMW\DIProperty;
+use SMW\SemanticData;
+use SMWDITime as DITime;;
+use SMW\ApprovedRevs\DatabaseLogReader;
+use SMW\ApprovedRevs\PropertyRegistry;
+use User;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ */
+class ApprovedDatePropertyAnnotator {
+
+	/**
+	 * @var DatabaseLogReader
+	 */
+	private $databaseLogReader;
+
+	/**
+	 * @var Integer|null
+	 */
+	private $approvedDate;
+
+	/**
+	 * @param DatabaseLogReader $databaseLogReader
+	 */
+	public function __construct( DatabaseLogReader $databaseLogReader ) {
+		$this->databaseLogReader = $databaseLogReader;
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param integer $approvedDate
+	 */
+	public function setApprovedDate( $approvedDate ) {
+		$this->approvedDate = $approvedDate;
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @return DIProperty
+	 */
+	public function newDIProperty() {
+		return new DIProperty( PropertyRegistry::SAR_PROP_APPROVED_DATE );
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param SemanticData $semanticData
+	 */
+	public function addAnnotation( SemanticData $semanticData ) {
+
+		if ( $this->approvedDate === null ) {
+			$this->approvedDate = $this->databaseLogReader->getDateOfLogEntry(
+				$semanticData->getSubject()->getTitle(),
+				'approval'
+			);
+		}
+
+		$property = $this->newDIProperty();
+		$dataItem = $this->newDITime();
+		$semanticData->removeProperty( $property );
+
+		if ( $dataItem ) {
+			$semanticData->addPropertyObjectValue( $property, $dataItem );
+		}
+	}
+
+	private function newDITime() {
+
+		if ( $this->approvedDate === null || is_bool( $this->approvedDate ) ) {
+			return;
+		}
+
+		$date = $this->approvedDate;
+
+		return new DITime(
+			DITime::CM_GREGORIAN,
+			$date->format( 'Y' ),
+			$date->format( 'm' ),
+			$date->format( 'd' ),
+			$date->format( 'H' ),
+			$date->format( 'i' )
+		);
+	}
+
+}

--- a/src/PropertyAnnotators/ApprovedRevPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ApprovedRevPropertyAnnotator.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SMW\ApprovedRevs\PropertyAnnotators;
+
+use SMW\DIProperty;
+use SMW\SemanticData;
+use SMWDINumber as DINumber;
+use SMW\ApprovedRevs\ApprovedRevsFacade;
+use SMW\ApprovedRevs\PropertyRegistry;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ */
+class ApprovedRevPropertyAnnotator {
+
+	/**
+	 * @var ApprovedRevsFacade
+	 */
+	private $approvedRevsFacade;
+
+	/**
+	 * @var Integer|null
+	 */
+	private $approvedRev;
+
+	/**
+	 * @param ApprovedRevsFacade $approvedRevsFacade
+	 */
+	public function __construct( ApprovedRevsFacade $approvedRevsFacade ) {
+		$this->approvedRevsFacade = $approvedRevsFacade;
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param integer $approvedRev
+	 */
+	public function setApprovedRev( $approvedRev ) {
+		$this->approvedRev = $approvedRev;
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @return DIProperty
+	 */
+	public function newDIProperty() {
+		return new DIProperty( PropertyRegistry::SAR_PROP_APPROVED_REV );
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param SemanticData $semanticData
+	 */
+	public function addAnnotation( SemanticData $semanticData ) {
+
+		if ( $this->approvedRev === null ) {
+			$this->approvedRev = $this->approvedRevsFacade->getApprovedRevID(
+				$semanticData->getSubject()->getTitle()
+			);
+		}
+
+		$property = $this->newDIProperty();
+		$semanticData->removeProperty( $property );
+
+		if ( is_numeric( $this->approvedRev ) ) {
+			$semanticData->addPropertyObjectValue(
+				$property,
+				$this->newDINumber()
+			);
+		}
+	}
+
+	private function newDINumber() {
+		return new DINumber( $this->approvedRev );
+	}
+
+}

--- a/src/PropertyAnnotators/ApprovedStatusPropertyAnnotator.php
+++ b/src/PropertyAnnotators/ApprovedStatusPropertyAnnotator.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace SMW\ApprovedRevs\PropertyAnnotators;
+
+use SMW\DIProperty;
+use SMW\SemanticData;
+use SMWDIBlob as DIBlob;
+use SMW\ApprovedRevs\DatabaseLogReader;
+use SMW\ApprovedRevs\PropertyRegistry;
+
+/**
+ * @private
+ *
+ * @license GNU GPL v2+
+ */
+class ApprovedStatusPropertyAnnotator {
+
+	/**
+	 * @var DatabaseLogReader
+	 */
+	private $databaseLogReader;
+
+	/**
+	 * @var Integer|null
+	 */
+	private $approvedStatus;
+
+	/**
+	 * @param DatabaseLogReader $databaseLogReader
+	 */
+	public function __construct( DatabaseLogReader $databaseLogReader ) {
+		$this->databaseLogReader = $databaseLogReader;
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param string $approvedStatus
+	 */
+	public function setApprovedStatus( $approvedStatus ) {
+		$this->approvedStatus = $approvedStatus;
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @return DIProperty
+	 */
+	public function newDIProperty() {
+		return new DIProperty( PropertyRegistry::SAR_PROP_APPROVED_STATUS );
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param SemanticData $semanticData
+	 */
+	public function addAnnotation( SemanticData $semanticData ) {
+
+		if ( $this->approvedStatus === null ) {
+			$this->approvedStatus = $this->databaseLogReader->getStatusOfLogEntry(
+				$semanticData->getSubject()->getTitle(),
+				'approval'
+			);
+		}
+
+		$property = $this->newDIProperty();
+		$semanticData->removeProperty( $property );
+
+		if ( is_string( $this->approvedStatus ) && $this->approvedStatus !== '' ) {
+			$semanticData->addPropertyObjectValue(
+				$property,
+				new DIBlob( $this->approvedStatus )
+			);
+		}
+	}
+
+}

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace SMW\ApprovedRevs;
+
+/**
+ * @license GNU GPL v2+
+ * @since 1.0
+ *
+ * @author mwjames
+ */
+class PropertyRegistry {
+
+	const SAR_PROP_APPROVED_REV = '__sar_approved_rev';
+	const SAR_PROP_APPROVED_BY = '__sar_approved_by';
+	const SAR_PROP_APPROVED_DATE = '__sar_approved_date';
+	const SAR_PROP_APPROVED_STATUS = '__sar_approved_status';
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param PropertyRegistry $propertyRegistry
+	 */
+	public function register( $propertyRegistry ) {
+
+		$defs = [
+			self::SAR_PROP_APPROVED_REV => [
+				'label' => 'Approved revision',
+				'type'  => '_num',
+				'alias' => 'semantic-approvedrevs-property-approved-rev',
+				'desc' => 'semantic-approvedrevs-property-approved-rev-desc',
+				'visbility' => false
+			],
+			self::SAR_PROP_APPROVED_BY => [
+				'label' => 'Approved by',
+				'type'  => '_wpg',
+				'alias' => 'semantic-approvedrevs-property-approved-by',
+				'desc' => 'semantic-approvedrevs-property-approved-by-desc',
+				'visbility' => false
+			],
+			self::SAR_PROP_APPROVED_DATE => [
+				'label' => 'Approved date',
+				'type'  => '_dat',
+				'alias' => 'semantic-approvedrevs-property-approved-date',
+				'desc' => 'semantic-approvedrevs-property-approved-date-desc',
+				'visbility' => false
+			],
+			self::SAR_PROP_APPROVED_STATUS => [
+				'label' => 'Approval status',
+				'type'  => '_txt',
+				'alias' => 'semantic-approvedrevs-property-approved-status',
+				'desc' => 'semantic-approvedrevs-property-approved-status-desc',
+				'visbility' => false
+			]
+		];
+
+		foreach ( $defs as $key => $definition ) {
+
+			$propertyRegistry->registerProperty(
+				$key,
+				$definition['type'],
+				$definition['label'],
+				$definition['visbility']
+			);
+
+			$propertyRegistry->registerPropertyAlias(
+				$key,
+				wfMessage( $definition['alias'] )->text()
+			);
+
+			$propertyRegistry->registerPropertyAliasByMsgKey(
+				$key,
+				$definition['alias']
+			);
+
+			$propertyRegistry->registerPropertyDescriptionMsgKeyById(
+				$key,
+				$definition['desc']
+			);
+		}
+	}
+
+}

--- a/src/ServicesFactory.php
+++ b/src/ServicesFactory.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace SMW\ApprovedRevs;
+
+use SMW\ApprovedRevs\PropertyAnnotators\ApprovedByPropertyAnnotator;
+use SMW\ApprovedRevs\PropertyAnnotators\ApprovedStatusPropertyAnnotator;
+use SMW\ApprovedRevs\PropertyAnnotators\ApprovedDatePropertyAnnotator;
+use SMW\ApprovedRevs\PropertyAnnotators\ApprovedRevPropertyAnnotator;
+use Title;
+
+/**
+ * @license GNU GPL v2+
+ * @since 1.0
+ *
+ * @author mwjames
+ */
+class ServicesFactory {
+
+	/**
+	 * @var DatabaseBase
+	 */
+	private $connection;
+
+	/**
+	 * @since 1.0
+	 */
+	public function setConnection( \DatabaseBase $connection ) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * @since 1.3
+	 *
+	 * @return DatabaseBase
+	 */
+	public function getConnection() {
+
+		if ( $this->connection === null ) {
+			$this->connection = wfGetDB( DB_SLAVE );
+		}
+
+		return $this->connection;
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @return ApprovedRevsFacade
+	 */
+	public function newApprovedRevsFacade() {
+		return new ApprovedRevsFacade();
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param null|Title $title to get the DBLogReader
+	 * @param string $type which log entries to get (default: approval)
+	 * @return DatabaseLogReader
+	 */
+	public function newDatabaseLogReader( Title $title = null, $type = 'approval' ) {
+		return new DatabaseLogReader( $this->getConnection(), $title, $type );
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @return ApprovedByPropertyAnnotator
+	 */
+	public function newApprovedByPropertyAnnotator() {
+		return new ApprovedByPropertyAnnotator( $this->newDatabaseLogReader() );
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @return ApprovedStatusPropertyAnnotator
+	 */
+	public function newApprovedStatusPropertyAnnotator() {
+		return new ApprovedStatusPropertyAnnotator( $this->newDatabaseLogReader() );
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @return ApprovedDatePropertyAnnotator
+	 */
+	public function newApprovedDatePropertyAnnotator() {
+		return new ApprovedDatePropertyAnnotator( $this->newDatabaseLogReader() );
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @return ApprovedRevPropertyAnnotator
+	 */
+	public function newApprovedRevPropertyAnnotator() {
+		return new ApprovedRevPropertyAnnotator( $this->newApprovedRevsFacade() );
+	}
+
+}

--- a/tests/phpunit/Unit/DatabaseLogReaderTest.php
+++ b/tests/phpunit/Unit/DatabaseLogReaderTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace SMW\ApprovedRevs\Tests;
+
+use SMW\ApprovedRevs\DatabaseLogReader;
+use SMW\ApprovedRevs\ServicesFactory;
+
+/**
+ * @covers \SMW\ApprovedRevs\DatabaseLogReader
+ * @group semantic-approved-revs
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ *
+ * @author mwjames
+ */
+class DatabaseLogReaderTest extends \PHPUnit_Framework_TestCase {
+
+	private $servicesFactory;
+	private $connection;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->servicesFactory = new ServicesFactory();
+
+		$this->connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+		$this->assertInstanceOf(
+			DatabaseLogReader::class,
+			$this->servicesFactory->newDatabaseLogReader()
+		);
+	}
+
+	public function testGetQuery() {
+		$log = $this->servicesFactory->newDatabaseLogReader();
+
+		$this->assertNull(
+			$log->getQuery()
+		);
+	}
+
+	public function testNoLog() {
+		$log = $this->servicesFactory->newDatabaseLogReader();
+
+		$this->assertNull(
+			$log->getUserForLogEntry()
+		);
+	}
+
+	public function testGetNull() {
+		$title = \Title::newFromText( "none" );
+
+		$log = $this->servicesFactory->newDatabaseLogReader( $title );
+
+		$this->assertNull(
+			$log->getUserForLogEntry()
+		);
+
+		$this->assertNull(
+			$log->getDateOfLogEntry()
+		);
+
+		$this->assertNull(
+			$log->getStatusOfLogEntry()
+		);
+
+		$query = $log->getQuery();
+
+		$this->assertEquals(
+			[ 'tables', 'fields', 'conds', 'options', 'join_conds' ],
+			array_keys( $query )
+		);
+	}
+
+	public function testGetLogAndQuery() {
+		$title = \Title::newFromText( __METHOD__ );
+
+		$row = new \stdClass;
+		$row->user_id = 1;
+		$row->log_timestamp = 5;
+		$row->log_action = 'bloop';
+
+		$this->connection->expects( $this->any() )
+			->method( 'select' )
+			->will( $this->returnValue( new \ArrayIterator( [ $row ] ) ) );
+
+		$this->servicesFactory->setConnection(
+			$this->connection
+		);
+
+		$log = $this->servicesFactory->newDatabaseLogReader();
+
+		$this->assertEquals(
+			\User::newFromID( 1 ),
+			$log->getUserForLogEntry( $title )
+		);
+
+		$this->assertEquals(
+			new \MWTimestamp( 5 ),
+			$log->getDateOfLogEntry( $title )
+		);
+
+		$this->assertEquals(
+			'bloop',
+			$log->getStatusOfLogEntry( $title )
+		);
+
+		$query = $log->getQuery();
+
+		$this->assertEquals(
+			[ 'tables', 'fields', 'conds', 'options', 'join_conds' ],
+			array_keys( $query )
+		);
+	}
+
+	public function testCache() {
+		$title = \Title::newFromText( __METHOD__ );
+
+		$row = new \stdClass;
+		$row->user_id = 1;
+		$row->log_timestamp = 5;
+		$row->log_action = 'bloop';
+
+		$this->connection->expects( $this->once() )
+			->method( 'select' )
+			->will( $this->returnValue( new \ArrayIterator( [ $row ] ) ) );
+
+		$this->servicesFactory->setConnection(
+			$this->connection
+		);
+
+		$log = $this->servicesFactory->newDatabaseLogReader();
+		$log->clearCache();
+
+		$this->assertEquals(
+			\User::newFromID( 1 ),
+			$log->getUserForLogEntry( $title )
+		);
+
+		// Second call on same title instance should be made from cache
+		$this->assertEquals(
+			\User::newFromID( 1 ),
+			$log->getUserForLogEntry( $title )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/PropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotatorTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace SMW\ApprovedRevs\Tests;
+
+use SMW\ApprovedRevs\PropertyAnnotator;
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+
+/**
+ * @covers \SMW\ApprovedRevs\PropertyAnnotator
+ * @group semantic-approved-revs
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ */
+class PropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
+
+	private $servicesFactory;
+	private $logger;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$approvedByPropertyAnnotator = $this->getMockBuilder( '\SMW\ApprovedRevs\PropertyAnnotators\ApprovedByPropertyAnnotator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$approvedStatusPropertyAnnotator = $this->getMockBuilder( '\SMW\ApprovedRevs\PropertyAnnotators\ApprovedStatusPropertyAnnotator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$approvedDatePropertyAnnotator = $this->getMockBuilder( '\SMW\ApprovedRevs\PropertyAnnotators\ApprovedDatePropertyAnnotator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$approvedRevPropertyAnnotator = $this->getMockBuilder( '\SMW\ApprovedRevs\PropertyAnnotators\ApprovedRevPropertyAnnotator' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->servicesFactory = $this->getMockBuilder( '\SMW\ApprovedRevs\ServicesFactory' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->servicesFactory->expects( $this->any() )
+			->method( 'newApprovedByPropertyAnnotator' )
+			->will( $this->returnValue( $approvedByPropertyAnnotator ) );
+
+		$this->servicesFactory->expects( $this->any() )
+			->method( 'newApprovedStatusPropertyAnnotator' )
+			->will( $this->returnValue( $approvedStatusPropertyAnnotator ) );
+
+		$this->servicesFactory->expects( $this->any() )
+			->method( 'newApprovedDatePropertyAnnotator' )
+			->will( $this->returnValue( $approvedDatePropertyAnnotator ) );
+
+		$this->servicesFactory->expects( $this->any() )
+			->method( 'newApprovedRevPropertyAnnotator' )
+			->will( $this->returnValue( $approvedRevPropertyAnnotator ) );
+
+		$this->logger = $this->getMockBuilder( '\Psr\Log\NullLogger' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			PropertyAnnotator::class,
+			new PropertyAnnotator( $this->servicesFactory )
+		);
+	}
+
+	public function testAddAnnotation() {
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'getSubject' )
+			->will( $this->returnValue( DIWikiPage::newFromText( 'Foo' ) ) );
+
+		$annotator = new PropertyAnnotator(
+			$this->servicesFactory
+		);
+
+		$annotator->setLogger( $this->logger );
+		$annotator->addAnnotation( $semanticData );
+	}
+
+}

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedByPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedByPropertyAnnotatorTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace SMW\ApprovedRevs\Tests\PropertyAnnotators;
+
+use SMW\ApprovedRevs\PropertyAnnotators\ApprovedByPropertyAnnotator;
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+use User;
+
+/**
+ * @covers \SMW\ApprovedRevs\PropertyAnnotators\ApprovedByPropertyAnnotator
+ * @group semantic-approved-revs
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ */
+class ApprovedByPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
+
+	private $databaseLogReader;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->databaseLogReader = $this->getMockBuilder( '\SMW\ApprovedRevs\DatabaseLogReader' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ApprovedByPropertyAnnotator::class,
+			new ApprovedByPropertyAnnotator( $this->databaseLogReader )
+		);
+	}
+
+	public function testAddAnnotation() {
+
+		$user = User::newFromName( "UnitTest" );
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'addPropertyObjectValue' )
+			->with(
+				$this->anyThing(),
+				$this->equalTo( DIWikiPage::newFromTitle( $user->getUserPage() ) ) );
+
+		$annotator = new ApprovedByPropertyAnnotator(
+			$this->databaseLogReader
+		);
+
+		$annotator->setApprovedBy( $user );
+		$annotator->addAnnotation( $semanticData );
+	}
+
+	public function testRemoval() {
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'removeProperty' );
+
+		$annotator = new ApprovedByPropertyAnnotator(
+			$this->databaseLogReader
+		);
+
+		$annotator->setApprovedBy( false );
+		$annotator->addAnnotation( $semanticData );
+	}
+
+}

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedDatePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedDatePropertyAnnotatorTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace SMW\ApprovedRevs\Tests\PropertyAnnotators;
+
+use SMW\ApprovedRevs\PropertyAnnotators\ApprovedDatePropertyAnnotator;
+use SMW\DIProperty;
+use MWTimestamp;
+use SMWDITime as DITime;
+
+/**
+ * @covers \SMW\ApprovedRevs\PropertyAnnotators\ApprovedDatePropertyAnnotator
+ * @group semantic-approved-revs
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ */
+class ApprovedDatePropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
+
+	private $databaseLogReader;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->databaseLogReader = $this->getMockBuilder( '\SMW\ApprovedRevs\DatabaseLogReader' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ApprovedDatePropertyAnnotator::class,
+			new ApprovedDatePropertyAnnotator( $this->databaseLogReader )
+		);
+	}
+
+	protected static function getDITime( MWTimestamp $time ) {
+		return new DITime(
+				DITime::CM_GREGORIAN,
+				$time->format( 'Y' ),
+				$time->format( 'm' ),
+				$time->format( 'd' ),
+				$time->format( 'H' ),
+				$time->format( 'i' )
+		);
+	}
+
+	public function testAddAnnotation() {
+
+		$now = new MWTimestamp( wfTimestampNow() );
+		$time = self::getDITime( $now );
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'addPropertyObjectValue' )
+			->with(
+				$this->anyThing(),
+				$this->equalTo( $time )
+			);
+
+		$annotator = new ApprovedDatePropertyAnnotator(
+			$this->databaseLogReader
+		);
+
+		$annotator->setApprovedDate( $now );
+		$annotator->addAnnotation( $semanticData );
+	}
+
+	public function testRemoval() {
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'removeProperty' );
+
+		$annotator = new ApprovedDatePropertyAnnotator(
+			$this->databaseLogReader
+		);
+
+		$annotator->setApprovedDate( false );
+		$annotator->addAnnotation( $semanticData );
+	}
+
+}

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedRevPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedRevPropertyAnnotatorTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SMW\ApprovedRevs\Tests\PropertyAnnotators;
+
+use SMW\ApprovedRevs\PropertyAnnotators\ApprovedRevPropertyAnnotator;
+use SMW\DIProperty;
+use SMW\DIWikiPage;
+use SMWDINumber as DINumber;
+
+/**
+ * @covers \SMW\ApprovedRevs\PropertyAnnotators\ApprovedRevPropertyAnnotator
+ * @group semantic-approved-revs
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ */
+class ApprovedRevPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
+
+	private $approvedRevsFacade;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->approvedRevsFacade = $this->getMockBuilder( '\SMW\ApprovedRevs\ApprovedRevsFacade' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ApprovedRevPropertyAnnotator::class,
+			new ApprovedRevPropertyAnnotator( $this->approvedRevsFacade )
+		);
+	}
+
+	public function testAddAnnotation() {
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'addPropertyObjectValue' )
+			->with(
+				$this->anyThing(),
+				$this->equalTo( new DINumber( 42 ) ) );
+
+		$annotator = new ApprovedRevPropertyAnnotator(
+			$this->approvedRevsFacade
+		);
+
+		$annotator->setApprovedRev( 42 );
+		$annotator->addAnnotation( $semanticData );
+	}
+
+	public function testRemoval() {
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'removeProperty' );
+
+		$annotator = new ApprovedRevPropertyAnnotator(
+			$this->approvedRevsFacade
+		);
+
+		$annotator->setApprovedRev( false );
+		$annotator->addAnnotation( $semanticData );
+	}
+
+}

--- a/tests/phpunit/Unit/PropertyAnnotators/ApprovedStatusPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/PropertyAnnotators/ApprovedStatusPropertyAnnotatorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace SMW\ApprovedRevs\Tests\PropertyAnnotators;
+
+use SMW\ApprovedRevs\PropertyAnnotators\ApprovedStatusPropertyAnnotator;
+use SMW\DIProperty;
+use SMWDIString as DIString;
+
+/**
+ * @covers \SMW\ApprovedRevs\PropertyAnnotators\ApprovedStatusPropertyAnnotator
+ * @group semantic-approved-revs
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ */
+class ApprovedStatusPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
+
+	private $databaseLogReader;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->databaseLogReader = $this->getMockBuilder( '\SMW\ApprovedRevs\DatabaseLogReader' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ApprovedStatusPropertyAnnotator::class,
+			new ApprovedStatusPropertyAnnotator( $this->databaseLogReader )
+		);
+	}
+
+	public function testAddAnnotation() {
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'addPropertyObjectValue' )
+			->with(
+				$this->anyThing(),
+				$this->equalTo( new DIString( "checkme" ) ) );
+
+		$annotator = new ApprovedStatusPropertyAnnotator(
+			$this->databaseLogReader
+		);
+
+		$annotator->setApprovedStatus( "checkme" );
+		$annotator->addAnnotation( $semanticData );
+	}
+
+	public function testRemoval() {
+
+		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$semanticData->expects( $this->once() )
+			->method( 'removeProperty' );
+
+		$annotator = new ApprovedStatusPropertyAnnotator(
+			$this->databaseLogReader
+		);
+
+		$annotator->setApprovedStatus( false );
+		$annotator->addAnnotation( $semanticData );
+	}
+
+}

--- a/tests/phpunit/Unit/PropertyRegistryTest.php
+++ b/tests/phpunit/Unit/PropertyRegistryTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace SMW\ApprovedRevs\Tests;
+
+use SMW\ApprovedRevs\PropertyRegistry;
+
+/**
+ * @covers \SMW\ApprovedRevs\PropertyRegistry
+ * @group semantic-approved-revs
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ *
+ * @author mwjames
+ */
+class PropertyRegistryTest extends \PHPUnit_Framework_TestCase {
+
+	private $propertyRegistry;
+
+	protected function setUp( ) {
+
+		$this->propertyRegistry = $this->getMockBuilder( '\SMW\PropertyRegistry' )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			PropertyRegistry::class,
+			new PropertyRegistry()
+		);
+	}
+
+	public function testRegister( ) {
+
+		$this->propertyRegistry->expects( $this->exactly( 4 ) )
+			->method( 'registerProperty' )
+			->withConsecutive(
+				[ $this->equalTo('__sar_approved_rev') ],
+				[ $this->equalTo('__sar_approved_by') ],
+				[ $this->equalTo('__sar_approved_date') ],
+				[ $this->equalTo('__sar_approved_status') ] );
+
+		$this->propertyRegistry->expects( $this->exactly( 4 ) )
+			->method( 'registerPropertyAlias' );
+
+		$this->propertyRegistry->expects( $this->exactly( 4 ) )
+			->method( 'registerPropertyAliasByMsgKey' );
+
+		$this->propertyRegistry->expects( $this->exactly( 4 ) )
+			->method( 'registerPropertyDescriptionMsgKeyById' );
+
+		$instance = new PropertyRegistry();
+
+		$instance->register( $this->propertyRegistry );
+	}
+
+}

--- a/tests/phpunit/Unit/ServicesFactoryTest.php
+++ b/tests/phpunit/Unit/ServicesFactoryTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace SMW\ApprovedRevs\Tests;
+
+use SMW\ApprovedRevs\ServicesFactory;
+
+/**
+ * @covers \SMW\ApprovedRevs\ServicesFactory
+ * @group semantic-approved-revs
+ *
+ * @license GNU GPL v2+
+ * @since 1.0
+ *
+ * @author mwjames
+ */
+class ServicesFactoryTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			ServicesFactory::class,
+			new ServicesFactory()
+		);
+	}
+
+	public function testGetConnection( ) {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new ServicesFactory();
+
+		$instance->setConnection(
+			$connection
+		);
+
+		$this->assertSame(
+			$connection,
+			$instance->getConnection()
+		);
+	}
+
+	public function testCanConstructApprovedRevsFacade( ) {
+
+		$instance = new ServicesFactory();
+
+		$this->assertInstanceOf(
+			'\SMW\ApprovedRevs\ApprovedRevsFacade',
+			$instance->newApprovedRevsFacade()
+		);
+	}
+
+	public function testCanConstructDatabaseLogReader() {
+
+		$connection = $this->getMockBuilder( '\DatabaseBase' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$appFactory = new ServicesFactory();
+		$appFactory->setConnection( $connection );
+
+		$dbLogReader = $appFactory->newDatabaseLogReader( null );
+		$dbLogReader->getStatusOfLogEntry();
+	}
+
+	/**
+	 * @dataProvider propertyAnnotatorsProvider
+	 */
+	public function testCanConstructPropertyAnnotators( $name, $instanceOf ) {
+
+		$instance = new ServicesFactory();
+
+		$this->assertInstanceOf(
+			$instanceOf,
+			call_user_func_array( [ $instance, $name ], [] )
+		);
+	}
+
+	public function propertyAnnotatorsProvider() {
+
+		yield [
+			'newApprovedByPropertyAnnotator',
+			'\SMW\ApprovedRevs\PropertyAnnotators\ApprovedByPropertyAnnotator'
+		];
+
+		yield [
+			'newApprovedStatusPropertyAnnotator',
+			'\SMW\ApprovedRevs\PropertyAnnotators\ApprovedStatusPropertyAnnotator'
+		];
+
+		yield [
+			'newApprovedDatePropertyAnnotator',
+			'\SMW\ApprovedRevs\PropertyAnnotators\ApprovedDatePropertyAnnotator'
+		];
+
+		yield [
+			'newApprovedRevPropertyAnnotator',
+			'\SMW\ApprovedRevs\PropertyAnnotators\ApprovedRevPropertyAnnotator'
+		];
+	}
+
+}

--- a/tests/travis/install-semantic-approved-revs.sh
+++ b/tests/travis/install-semantic-approved-revs.sh
@@ -19,10 +19,10 @@ function installToMediaWikiRoot {
 
 	if [ "$SAR" != "" ]
 	then
-		composer require 'mediawiki/install-semantic-approved-revs='$SAR --prefer-source --update-with-dependencies
+		composer require 'mediawiki/semantic-approved-revs='$SAR --prefer-source --update-with-dependencies
 	else
 		composer init --stability dev
-		composer require mediawiki/install-semantic-approved-revs "dev-master" --prefer-source --dev --update-with-dependencies
+		composer require mediawiki/semantic-approved-revs "dev-master" --prefer-source --dev --update-with-dependencies
 
 		cd extensions
 		cd SemanticApprovedRevs
@@ -42,6 +42,15 @@ function installToMediaWikiRoot {
 
 		cd ../..
 	fi
+
+	cd $MW_INSTALL_PATH/extensions
+
+	wget https://github.com/wikimedia/mediawiki-extensions-ApprovedRevs/archive/$APPROVED_REVS.tar.gz
+
+	tar -zxf $APPROVED_REVS.tar.gz
+	mv mediawiki-* ApprovedRevs
+
+	cd $MW_INSTALL_PATH
 
 	# Rebuild the class map for added classes during git fetch
 	composer dump-autoload
@@ -64,6 +73,7 @@ function updateConfiguration {
 	echo "putenv( 'MW_INSTALL_PATH=$(pwd)' );" >> LocalSettings.php
 
 	echo 'wfLoadExtension( "SemanticMediaWiki" );' >> LocalSettings.php
+	echo 'wfLoadExtension( "ApprovedRevs" );' >> LocalSettings.php
 	echo 'wfLoadExtension( "SemanticApprovedRevs" );' >> LocalSettings.php
 
 	php maintenance/update.php --quick


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticExtraSpecialProperties/issues/108#issuecomment-466810974

This PR addresses or contains:

- Copies `Approved by`, `Approved date`, `Approved revision`, and `Approval status` properties (and annotation logic) from SESP to this repo

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
