### PR TITLE
Use `RevisionGuard` hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 [![Latest Stable Version](https://poser.pugx.org/mediawiki/semantic-approved-revs/version.png)](https://packagist.org/packages/mediawiki/semantic-approved-revs)
 [![Packagist download count](https://poser.pugx.org/mediawiki/semantic-approved-revs/d/total.png)](https://packagist.org/packages/mediawiki/semantic-approved-revs)
 
-Semantic Approved Revs (a.k.a. SAR) is an extension to [Semantic MediaWiki][smw] and complements the Approved Revs extension to control the storage of approved revision content. The extension provides:
+Semantic Approved Revs (a.k.a. SAR) is a [Semantic MediaWiki][smw] extension and a complement to the Approved Revs extension to help store data related to an approved revision. The extension provides:
 
-- Control of Semantic MediaWiki related updates to match those of the `Approved Revs` hereby ensuring that only data of the approved revision is used for the storage
+- Control over Semantic MediaWiki related updates to only store data for an approved revision (managed by `Approved Revs`)
 - Provides additional properties (`Approved by`, `Approved date`, `Approved revision`, and `Approval status`) to accompany the approval process
 
-This short [video](https://youtu.be/cl9XmzKQ2Ec) demonstrates the interaction between the Semantic MediaWiki, Semantic Approved Revs, and Approved Revs extension.
+This short [video](https://youtu.be/cl9XmzKQ2Ec) demonstrates the interaction between the Semantic MediaWiki, Semantic Approved Revs, and the Approved Revs extension.
 
 ## Requirements
 

--- a/SemanticApprovedRevs.php
+++ b/SemanticApprovedRevs.php
@@ -46,6 +46,10 @@ class SemanticApprovedRevs {
 		define( 'SMW_APPROVED_REVS_VERSION', $version );
 
 		$GLOBALS['wgMessagesDirs']['SemanticApprovedRevs'] = __DIR__ . '/i18n';
+
+		// Register hooks that require to be listed as soon as possible and preferable
+		// before the execution of onExtensionFunction
+		Hooks::initExtension( $GLOBALS );
 	}
 
 	/**

--- a/src/ApprovedRevsFacade.php
+++ b/src/ApprovedRevsFacade.php
@@ -18,7 +18,7 @@ use ApprovedRevs;
 class ApprovedRevsFacade {
 
 	/**
-	 * @since  1.0
+	 * @since 1.0
 	 *
 	 * @param Title $title
 	 *
@@ -29,7 +29,7 @@ class ApprovedRevsFacade {
 	}
 
 	/**
-	 * @since  1.0
+	 * @since 1.0
 	 *
 	 * @param Title $title
 	 *
@@ -40,7 +40,7 @@ class ApprovedRevsFacade {
 	}
 
 	/**
-	 * @since  1.0
+	 * @since 1.0
 	 *
 	 * @param Title $title
 	 *
@@ -48,6 +48,15 @@ class ApprovedRevsFacade {
 	 */
 	public function getApprovedFileInfo( Title $title ) {
 		return ApprovedRevs::getApprovedFileInfo( $title );
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param Title $title
+	 */
+	public function clearApprovedFileInfo( Title $title ) {
+		unset( ApprovedRevs::$mApprovedFileInfo[ $title->getDBkey() ] );
 	}
 
 }

--- a/src/ApprovedRevsHandler.php
+++ b/src/ApprovedRevsHandler.php
@@ -98,7 +98,14 @@ class ApprovedRevsHandler {
 	 */
 	public function doChangeFile( Title $title, &$file ) {
 
-		list( $timestamp, $file_sha1 ) = $this->approvedRevsFacade->getApprovedFileInfo( $title );
+		// It has been observed that when running `runJobs.php` with `--wait`
+		// the `ApprovedRevs` instance holds an outdated cache entry therefore
+		// clear the static before trying to get the info
+		$this->approvedRevsFacade->clearApprovedFileInfo( $title );
+
+		list( $timestamp, $file_sha1 ) = $this->approvedRevsFacade->getApprovedFileInfo(
+			$title
+		);
 
 		if ( $file_sha1 === false ) {
 			return true;

--- a/tests/phpunit/Unit/ApprovedRevsFacadeTest.php
+++ b/tests/phpunit/Unit/ApprovedRevsFacadeTest.php
@@ -62,6 +62,31 @@ class ApprovedRevsFacadeTest extends \PHPUnit_Framework_TestCase {
 			'array',
 			$instance->getApprovedFileInfo( $title )
 		);
+
+	}
+
+	public function testClearApprovedFileInfo() {
+
+		$this->assertTrue(
+			property_exists( new \ApprovedRevs(), 'mApprovedFileInfo' )
+		);
+
+		$title = $this->getMockBuilder( '\Title' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new ApprovedRevsFacade();
+
+		$this->assertInternalType(
+			'array',
+			$instance->getApprovedFileInfo( $title )
+		);
+
+		$title->expects( $this->once() )
+			->method( 'getDBkey' );
+
+		$instance = new ApprovedRevsFacade();
+		$instance->clearApprovedFileInfo( $title );
 	}
 
 }

--- a/tests/phpunit/Unit/HooksTest.php
+++ b/tests/phpunit/Unit/HooksTest.php
@@ -34,14 +34,13 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 		$this->callOnApprovedRevsRevisionApproved( $instance );
 		$this->callOnApprovedRevsFileRevisionApproved( $instance );
 
-		$this->callOnSMWLinksUpdateApprovedUpdate( $instance );
-		$this->callOnSMWDataUpdaterSkipUpdate( $instance );
-		$this->callOnSMWParserChangeRevision( $instance );
-		$this->callOnSMWFactboxOverrideRevisionID( $instance );
+		$this->callOnSMWRevisionGuardIsApprovedRevision( $instance );
+		$this->callOnSMWRevisionGuardChangeRevision( $instance );
+		$this->callOnSMWRevisionGuardChangeRevisionID( $instance );
 		$this->callOnSMWInitProperties( $instance );
 		$this->callOnSMWStoreUpdateDataBefore( $instance );
 		$this->callOnSMWConfigBeforeCompletion( $instance );
-		$this->callOnSMWElasticStoreFileIndexerChangeFileBeforeIngestProcessComplete( $instance );
+		$this->callOnSMWRevisionGuardChangeFile( $instance );
 	}
 
 	public function callOnApprovedRevsRevisionApproved( $instance ) {
@@ -108,29 +107,9 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function callOnSMWLinksUpdateApprovedUpdate( $instance ) {
+	public function callOnSMWRevisionGuardIsApprovedRevision( $instance ) {
 
-		$handler = 'SMW::LinksUpdate::ApprovedUpdate';
-
-		$title = $this->getMockBuilder( '\Title' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->assertTrue(
-			$instance->isRegistered( $handler )
-		);
-
-		$rev = 0;
-
-		$this->assertThatHookIsExcutable(
-			$instance->getHandlers( $handler ),
-			[ $title, $rev ]
-		);
-	}
-
-	public function callOnSMWDataUpdaterSkipUpdate( $instance ) {
-
-		$handler = 'SMW::DataUpdater::SkipUpdate';
+		$handler = 'SMW::RevisionGuard::IsApprovedRevision';
 
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
@@ -148,9 +127,9 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function callOnSMWParserChangeRevision( $instance ) {
+	public function callOnSMWRevisionGuardChangeRevision( $instance ) {
 
-		$handler = 'SMW::Parser::ChangeRevision';
+		$handler = 'SMW::RevisionGuard::ChangeRevision';
 
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
@@ -168,9 +147,9 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function callOnSMWFactboxOverrideRevisionID( $instance ) {
+	public function callOnSMWRevisionGuardChangeRevisionID( $instance ) {
 
-		$handler = 'SMW::Factbox::OverrideRevisionID';
+		$handler = 'SMW::RevisionGuard::ChangeRevisionID';
 
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
@@ -251,9 +230,9 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function callOnSMWElasticStoreFileIndexerChangeFileBeforeIngestProcessComplete( $instance ) {
+	public function callOnSMWRevisionGuardChangeFile( $instance ) {
 
-		$handler = 'SMW::ElasticStore::FileIndexer::ChangeFileBeforeIngestProcessComplete';
+		$handler = 'SMW::RevisionGuard::ChangeFile';
 
 		$this->assertTrue(
 			$instance->isRegistered( $handler )


### PR DESCRIPTION
Replace hooks with the newly introduced `RevisionGuard` hooks. See https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/3897 for the rational.